### PR TITLE
i#2860 website: Exclude local repository files

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -26,13 +26,14 @@ plugins:
   - jekyll-redirect-from
 
 # Exclude from processing.
-# The following items will not be processed, by default. Create a custom list
-# to override the default setting.
-# exclude:
-#   - Gemfile
-#   - Gemfile.lock
-#   - node_modules
-#   - vendor/bundle/
-#   - vendor/cache/
-#   - vendor/gems/
-#   - vendor/ruby/
+exclude:
+  - Gemfile
+  - Gemfile.lock
+  - node_modules
+  - vendor/bundle/
+  - vendor/cache/
+  - vendor/gems/
+  - vendor/ruby/
+  - README.md
+  - LICENSE
+  - CNAME


### PR DESCRIPTION
Adds exclusions for REAMDE.md, LICENSE, and CNAME files which are not
meant to be on the web site.

Issue: DynamoRIO/dynamorio#2860