### PR TITLE
Nav bar cleanup: rm arrow; mobile search; greener

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -72,12 +72,12 @@
       </a>
     </div>
 
-    <form id="search-form" action="/search" method="get">
-      <input type="text" name="query" id="search-input" placeholder="Search">
-      <input type="submit" value="Search" style="display: none;">
-    </form>
-
     <div id="nav-tree" class="menus medbg noxscroll mobile-invisible mobile-toggle">
+      <form id="search-form" class="medbg" action="/search" method="get">
+        <input type="text" name="query" id="search-input" class="medbg"
+               placeholder="Search">
+        <input type="submit" value="Search" style="display: none;">
+      </form>
       <div id="nav-tree-contents" class="medbg noxscroll mobile-invisible mobile-toggle">
       </div>
       <div id="nav-sync" class="medbg sync noxscroll mobile-invisible mobile-toggle">

--- a/navtree.css
+++ b/navtree.css
@@ -65,7 +65,7 @@
   padding:0px;
 }
 
-#nav-tree {
+#nav-tree-disabled {
   padding: 0px 0px;
   background-color: #FAFAFF; 
   font-size:14px;
@@ -116,7 +116,7 @@
   margin: 0px 0px 0px 0px;
 }
 
-#nav-tree {
+#nav-tree-disabled {
   background-image:url('/images/nav_h.png');
   background-repeat:repeat-x;
   background-color: #F9FAFC;

--- a/navtree.js
+++ b/navtree.js
@@ -476,7 +476,6 @@ function navTo(o,root,hash,relpath)
       indices.pop();
       ++indices[indices.length-1];
       if (arrays.length == 0) {
-        console.log('failed to find '+root);
         indices = [0]; // fallback: show home
         break;
       }

--- a/style.scss
+++ b/style.scss
@@ -22,11 +22,11 @@ body {
 }
 
 .darkbg {
-    background: #f4fcf8;
+    background: #edf8ec;
 }
 
 .medbg {
-    background: #f4fcf8;
+    background: #edf8ec;
 }
 
 .ltbg, a.curpage {
@@ -56,7 +56,7 @@ header.sidebar {
     height: 100vh;
     overflow-x: hidden;
     left: 0px;
-    border-right: 3px ridge #f4fcf8;
+    border-right: 3px ridge #edf8ec;
     border-bottom: 0px;
     @media (max-width: $topmenu-trigger-width) {
         position: static;
@@ -65,7 +65,7 @@ header.sidebar {
         width: 100vw;
         overflow-x: visible;
         border-right: 0px;
-        border-bottom: 3px ridge #f4fcf8;
+        border-bottom: 3px ridge #edf8ec;
     }
 }
 
@@ -297,17 +297,10 @@ form {margin-bottom: 0px;}
 #search-input {
     display: block;
     margin: auto;
-    margin-top: 1em;
-    @media (max-width: $topmenu-trigger-width) {
-        display: inline-block;
-        margin-top: 0em;
-    }
+    margin-bottom: 1em;
 }
 
-#search-form {
-    @media (max-width: $topmenu-trigger-width) {
-        display: inline-block;
-        vertical-align: top;
-        margin-top: 75px;
-    }
+#nav-sync {
+    // We decided we don't want to show the double-array and to always sync the menu.
+    display: none;
 }


### PR DESCRIPTION
Cleans up the nav bar by removing the synch double-arrow (and just
always synchronizing the menus).
Tweaks the color to be a litle more green.
Moves the search box to be part of the menu, so it's visible on a
narrow mobile screen.