### PR TITLE
Add redirects for dynamorio_docs/ pages

### DIFF
--- a/dynamorio_docs/API_BT.md
+++ b/dynamorio_docs/API_BT.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /API_BT.html
+---

--- a/dynamorio_docs/API_samples.md
+++ b/dynamorio_docs/API_samples.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /API_samples.html
+---

--- a/dynamorio_docs/API_tutorial.md
+++ b/dynamorio_docs/API_tutorial.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /API_tutorial.html
+---

--- a/dynamorio_docs/API_tutorial_annotation1.md
+++ b/dynamorio_docs/API_tutorial_annotation1.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /API_tutorial_annotation1.html
+---

--- a/dynamorio_docs/API_tutorial_annotation2.md
+++ b/dynamorio_docs/API_tutorial_annotation2.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /API_tutorial_annotation2.html
+---

--- a/dynamorio_docs/API_tutorial_annotation3.md
+++ b/dynamorio_docs/API_tutorial_annotation3.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /API_tutorial_annotation3.html
+---

--- a/dynamorio_docs/API_tutorial_annotation4.md
+++ b/dynamorio_docs/API_tutorial_annotation4.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /API_tutorial_annotation4.html
+---

--- a/dynamorio_docs/API_tutorial_annotation5.md
+++ b/dynamorio_docs/API_tutorial_annotation5.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /API_tutorial_annotation5.html
+---

--- a/dynamorio_docs/API_tutorial_annotation6.md
+++ b/dynamorio_docs/API_tutorial_annotation6.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /API_tutorial_annotation6.html
+---

--- a/dynamorio_docs/API_tutorial_annotation7.md
+++ b/dynamorio_docs/API_tutorial_annotation7.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /API_tutorial_annotation7.html
+---

--- a/dynamorio_docs/API_tutorial_bbdynsize1.md
+++ b/dynamorio_docs/API_tutorial_bbdynsize1.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /API_tutorial_bbdynsize1.html
+---

--- a/dynamorio_docs/API_tutorial_bbdynsize2.md
+++ b/dynamorio_docs/API_tutorial_bbdynsize2.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /API_tutorial_bbdynsize2.html
+---

--- a/dynamorio_docs/API_tutorial_bbdynsize3.md
+++ b/dynamorio_docs/API_tutorial_bbdynsize3.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /API_tutorial_bbdynsize3.html
+---

--- a/dynamorio_docs/API_tutorial_bbdynsize4.md
+++ b/dynamorio_docs/API_tutorial_bbdynsize4.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /API_tutorial_bbdynsize4.html
+---

--- a/dynamorio_docs/API_tutorial_bbdynsize5.md
+++ b/dynamorio_docs/API_tutorial_bbdynsize5.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /API_tutorial_bbdynsize5.html
+---

--- a/dynamorio_docs/API_tutorial_bbdynsize6.md
+++ b/dynamorio_docs/API_tutorial_bbdynsize6.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /API_tutorial_bbdynsize6.html
+---

--- a/dynamorio_docs/API_tutorial_bbdynsize7.md
+++ b/dynamorio_docs/API_tutorial_bbdynsize7.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /API_tutorial_bbdynsize7.html
+---

--- a/dynamorio_docs/API_tutorial_bbdynsize8.md
+++ b/dynamorio_docs/API_tutorial_bbdynsize8.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /API_tutorial_bbdynsize8.html
+---

--- a/dynamorio_docs/API_tutorial_bbdynsize9.md
+++ b/dynamorio_docs/API_tutorial_bbdynsize9.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /API_tutorial_bbdynsize9.html
+---

--- a/dynamorio_docs/API_tutorial_prefetch1.md
+++ b/dynamorio_docs/API_tutorial_prefetch1.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /API_tutorial_prefetch1.html
+---

--- a/dynamorio_docs/API_tutorial_steal_reg1.md
+++ b/dynamorio_docs/API_tutorial_steal_reg1.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /API_tutorial_steal_reg1.html
+---

--- a/dynamorio_docs/annotated.md
+++ b/dynamorio_docs/annotated.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /annotated.html
+---

--- a/dynamorio_docs/basic__counts__create_8h.md
+++ b/dynamorio_docs/basic__counts__create_8h.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /basic__counts__create_8h.html
+---

--- a/dynamorio_docs/cache__simulator__create_8h.md
+++ b/dynamorio_docs/cache__simulator__create_8h.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /cache__simulator__create_8h.html
+---

--- a/dynamorio_docs/deprecated.md
+++ b/dynamorio_docs/deprecated.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /deprecated.html
+---

--- a/dynamorio_docs/dr__annotation_8h.md
+++ b/dynamorio_docs/dr__annotation_8h.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /dr__annotation_8h.html
+---

--- a/dynamorio_docs/dr__api_8h.md
+++ b/dynamorio_docs/dr__api_8h.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /dr__api_8h.html
+---

--- a/dynamorio_docs/dr__app_8h.md
+++ b/dynamorio_docs/dr__app_8h.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /dr__app_8h.html
+---

--- a/dynamorio_docs/dr__config_8h.md
+++ b/dynamorio_docs/dr__config_8h.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /dr__config_8h.html
+---

--- a/dynamorio_docs/dr__defines_8h.md
+++ b/dynamorio_docs/dr__defines_8h.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /dr__defines_8h.html
+---

--- a/dynamorio_docs/dr__events_8h.md
+++ b/dynamorio_docs/dr__events_8h.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /dr__events_8h.html
+---

--- a/dynamorio_docs/dr__frontend_8h.md
+++ b/dynamorio_docs/dr__frontend_8h.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /dr__frontend_8h.html
+---

--- a/dynamorio_docs/dr__inject_8h.md
+++ b/dynamorio_docs/dr__inject_8h.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /dr__inject_8h.html
+---

--- a/dynamorio_docs/dr__ir__instr_8h.md
+++ b/dynamorio_docs/dr__ir__instr_8h.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /dr__ir__instr_8h.html
+---

--- a/dynamorio_docs/dr__ir__instrlist_8h.md
+++ b/dynamorio_docs/dr__ir__instrlist_8h.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /dr__ir__instrlist_8h.html
+---

--- a/dynamorio_docs/dr__ir__macros_8h.md
+++ b/dynamorio_docs/dr__ir__macros_8h.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /dr__ir__macros_8h.html
+---

--- a/dynamorio_docs/dr__ir__macros__aarch64_8h.md
+++ b/dynamorio_docs/dr__ir__macros__aarch64_8h.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /dr__ir__macros__aarch64_8h.html
+---

--- a/dynamorio_docs/dr__ir__macros__arm_8h.md
+++ b/dynamorio_docs/dr__ir__macros__arm_8h.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /dr__ir__macros__arm_8h.html
+---

--- a/dynamorio_docs/dr__ir__macros__x86_8h.md
+++ b/dynamorio_docs/dr__ir__macros__x86_8h.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /dr__ir__macros__x86_8h.html
+---

--- a/dynamorio_docs/dr__ir__opcodes__arm_8h.md
+++ b/dynamorio_docs/dr__ir__opcodes__arm_8h.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /dr__ir__opcodes__arm_8h.html
+---

--- a/dynamorio_docs/dr__ir__opcodes__x86_8h.md
+++ b/dynamorio_docs/dr__ir__opcodes__x86_8h.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /dr__ir__opcodes__x86_8h.html
+---

--- a/dynamorio_docs/dr__ir__opnd_8h.md
+++ b/dynamorio_docs/dr__ir__opnd_8h.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /dr__ir__opnd_8h.html
+---

--- a/dynamorio_docs/dr__ir__utils_8h.md
+++ b/dynamorio_docs/dr__ir__utils_8h.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /dr__ir__utils_8h.html
+---

--- a/dynamorio_docs/dr__proc_8h.md
+++ b/dynamorio_docs/dr__proc_8h.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /dr__proc_8h.html
+---

--- a/dynamorio_docs/dr__tools_8h.md
+++ b/dynamorio_docs/dr__tools_8h.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /dr__tools_8h.html
+---

--- a/dynamorio_docs/drbbdup_8h.md
+++ b/dynamorio_docs/drbbdup_8h.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /drbbdup_8h.html
+---

--- a/dynamorio_docs/drcovlib_8h.md
+++ b/dynamorio_docs/drcovlib_8h.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /drcovlib_8h.html
+---

--- a/dynamorio_docs/drmemtrace_8h.md
+++ b/dynamorio_docs/drmemtrace_8h.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /drmemtrace_8h.html
+---

--- a/dynamorio_docs/drmgr_8h.md
+++ b/dynamorio_docs/drmgr_8h.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /drmgr_8h.html
+---

--- a/dynamorio_docs/droption_8h.md
+++ b/dynamorio_docs/droption_8h.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /droption_8h.html
+---

--- a/dynamorio_docs/drreg_8h.md
+++ b/dynamorio_docs/drreg_8h.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /drreg_8h.html
+---

--- a/dynamorio_docs/drsyms_8h.md
+++ b/dynamorio_docs/drsyms_8h.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /drsyms_8h.html
+---

--- a/dynamorio_docs/drtable_8h.md
+++ b/dynamorio_docs/drtable_8h.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /drtable_8h.html
+---

--- a/dynamorio_docs/drutil_8h.md
+++ b/dynamorio_docs/drutil_8h.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /drutil_8h.html
+---

--- a/dynamorio_docs/drvector_8h.md
+++ b/dynamorio_docs/drvector_8h.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /drvector_8h.html
+---

--- a/dynamorio_docs/drwrap_8h.md
+++ b/dynamorio_docs/drwrap_8h.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /drwrap_8h.html
+---

--- a/dynamorio_docs/drx_8h.md
+++ b/dynamorio_docs/drx_8h.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /drx_8h.html
+---

--- a/dynamorio_docs/files.md
+++ b/dynamorio_docs/files.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /files.html
+---

--- a/dynamorio_docs/func__view__create_8h.md
+++ b/dynamorio_docs/func__view__create_8h.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /func__view__create_8h.html
+---

--- a/dynamorio_docs/hashtable_8h.md
+++ b/dynamorio_docs/hashtable_8h.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /hashtable_8h.html
+---

--- a/dynamorio_docs/hierarchy.md
+++ b/dynamorio_docs/hierarchy.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /hierarchy.html
+---

--- a/dynamorio_docs/histogram__create_8h.md
+++ b/dynamorio_docs/histogram__create_8h.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /histogram__create_8h.html
+---

--- a/dynamorio_docs/index.md
+++ b/dynamorio_docs/index.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /index.html
+---

--- a/dynamorio_docs/memref_8h.md
+++ b/dynamorio_docs/memref_8h.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /memref_8h.html
+---

--- a/dynamorio_docs/modules.md
+++ b/dynamorio_docs/modules.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /modules.html
+---

--- a/dynamorio_docs/opcode__mix__create_8h.md
+++ b/dynamorio_docs/opcode__mix__create_8h.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /opcode__mix__create_8h.html
+---

--- a/dynamorio_docs/overview.md
+++ b/dynamorio_docs/overview.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /overview.html
+---

--- a/dynamorio_docs/page_aarch64_far.md
+++ b/dynamorio_docs/page_aarch64_far.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_aarch64_far.html
+---

--- a/dynamorio_docs/page_aarch64_port.md
+++ b/dynamorio_docs/page_aarch64_port.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_aarch64_port.html
+---

--- a/dynamorio_docs/page_additional_tools.md
+++ b/dynamorio_docs/page_additional_tools.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_additional_tools.html
+---

--- a/dynamorio_docs/page_annotations.md
+++ b/dynamorio_docs/page_annotations.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_annotations.html
+---

--- a/dynamorio_docs/page_arm_port.md
+++ b/dynamorio_docs/page_arm_port.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_arm_port.html
+---

--- a/dynamorio_docs/page_bug_reporting.md
+++ b/dynamorio_docs/page_bug_reporting.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_bug_reporting.html
+---

--- a/dynamorio_docs/page_build_client.md
+++ b/dynamorio_docs/page_build_client.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_build_client.html
+---

--- a/dynamorio_docs/page_building.md
+++ b/dynamorio_docs/page_building.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_building.html
+---

--- a/dynamorio_docs/page_code_content.md
+++ b/dynamorio_docs/page_code_content.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_code_content.html
+---

--- a/dynamorio_docs/page_code_reviews.md
+++ b/dynamorio_docs/page_code_reviews.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_code_reviews.html
+---

--- a/dynamorio_docs/page_code_style.md
+++ b/dynamorio_docs/page_code_style.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_code_style.html
+---

--- a/dynamorio_docs/page_code_tips.md
+++ b/dynamorio_docs/page_code_tips.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_code_tips.html
+---

--- a/dynamorio_docs/page_contributing.md
+++ b/dynamorio_docs/page_contributing.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_contributing.html
+---

--- a/dynamorio_docs/page_debug_memtrace.md
+++ b/dynamorio_docs/page_debug_memtrace.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_debug_memtrace.html
+---

--- a/dynamorio_docs/page_debugging.md
+++ b/dynamorio_docs/page_debugging.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_debugging.html
+---

--- a/dynamorio_docs/page_deploy.md
+++ b/dynamorio_docs/page_deploy.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_deploy.html
+---

--- a/dynamorio_docs/page_design_docs.md
+++ b/dynamorio_docs/page_design_docs.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_design_docs.html
+---

--- a/dynamorio_docs/page_dev_docs.md
+++ b/dynamorio_docs/page_dev_docs.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_dev_docs.html
+---

--- a/dynamorio_docs/page_download.md
+++ b/dynamorio_docs/page_download.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_download.html
+---

--- a/dynamorio_docs/page_drbbdup.md
+++ b/dynamorio_docs/page_drbbdup.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_drbbdup.html
+---

--- a/dynamorio_docs/page_drcachesim.md
+++ b/dynamorio_docs/page_drcachesim.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_drcachesim.html
+---

--- a/dynamorio_docs/page_drcontainers.md
+++ b/dynamorio_docs/page_drcontainers.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_drcontainers.html
+---

--- a/dynamorio_docs/page_drcov.md
+++ b/dynamorio_docs/page_drcov.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_drcov.html
+---

--- a/dynamorio_docs/page_drcovlib.md
+++ b/dynamorio_docs/page_drcovlib.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_drcovlib.html
+---

--- a/dynamorio_docs/page_drcpusim.md
+++ b/dynamorio_docs/page_drcpusim.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_drcpusim.html
+---

--- a/dynamorio_docs/page_drdisas.md
+++ b/dynamorio_docs/page_drdisas.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_drdisas.html
+---

--- a/dynamorio_docs/page_drgui.md
+++ b/dynamorio_docs/page_drgui.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_drgui.html
+---

--- a/dynamorio_docs/page_drltrace.md
+++ b/dynamorio_docs/page_drltrace.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_drltrace.html
+---

--- a/dynamorio_docs/page_drmemory.md
+++ b/dynamorio_docs/page_drmemory.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_drmemory.html
+---

--- a/dynamorio_docs/page_drmf_drsymcache.md
+++ b/dynamorio_docs/page_drmf_drsymcache.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_drmf_drsymcache.html
+---

--- a/dynamorio_docs/page_drmf_drsyscall.md
+++ b/dynamorio_docs/page_drmf_drsyscall.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_drmf_drsyscall.html
+---

--- a/dynamorio_docs/page_drmf_umbra.md
+++ b/dynamorio_docs/page_drmf_umbra.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_drmf_umbra.html
+---

--- a/dynamorio_docs/page_drmgr.md
+++ b/dynamorio_docs/page_drmgr.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_drmgr.html
+---

--- a/dynamorio_docs/page_droption.md
+++ b/dynamorio_docs/page_droption.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_droption.html
+---

--- a/dynamorio_docs/page_drreg.md
+++ b/dynamorio_docs/page_drreg.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_drreg.html
+---

--- a/dynamorio_docs/page_drstrace.md
+++ b/dynamorio_docs/page_drstrace.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_drstrace.html
+---

--- a/dynamorio_docs/page_drsyms.md
+++ b/dynamorio_docs/page_drsyms.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_drsyms.html
+---

--- a/dynamorio_docs/page_drutil.md
+++ b/dynamorio_docs/page_drutil.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_drutil.html
+---

--- a/dynamorio_docs/page_drwrap.md
+++ b/dynamorio_docs/page_drwrap.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_drwrap.html
+---

--- a/dynamorio_docs/page_drx.md
+++ b/dynamorio_docs/page_drx.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_drx.html
+---

--- a/dynamorio_docs/page_ext.md
+++ b/dynamorio_docs/page_ext.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_ext.html
+---

--- a/dynamorio_docs/page_external_decoder.md
+++ b/dynamorio_docs/page_external_decoder.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_external_decoder.html
+---

--- a/dynamorio_docs/page_help.md
+++ b/dynamorio_docs/page_help.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_help.html
+---

--- a/dynamorio_docs/page_history.md
+++ b/dynamorio_docs/page_history.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_history.html
+---

--- a/dynamorio_docs/page_home.md
+++ b/dynamorio_docs/page_home.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_home.html
+---

--- a/dynamorio_docs/page_jitopt.md
+++ b/dynamorio_docs/page_jitopt.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_jitopt.html
+---

--- a/dynamorio_docs/page_ldstex.md
+++ b/dynamorio_docs/page_ldstex.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_ldstex.html
+---

--- a/dynamorio_docs/page_license.md
+++ b/dynamorio_docs/page_license.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_license.html
+---

--- a/dynamorio_docs/page_logging.md
+++ b/dynamorio_docs/page_logging.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_logging.html
+---

--- a/dynamorio_docs/page_new_release.md
+++ b/dynamorio_docs/page_new_release.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_new_release.html
+---

--- a/dynamorio_docs/page_profiling.md
+++ b/dynamorio_docs/page_profiling.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_profiling.html
+---

--- a/dynamorio_docs/page_publications.md
+++ b/dynamorio_docs/page_publications.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_publications.html
+---

--- a/dynamorio_docs/page_releases.md
+++ b/dynamorio_docs/page_releases.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_releases.html
+---

--- a/dynamorio_docs/page_rseq.md
+++ b/dynamorio_docs/page_rseq.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_rseq.html
+---

--- a/dynamorio_docs/page_slides.md
+++ b/dynamorio_docs/page_slides.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_slides.html
+---

--- a/dynamorio_docs/page_source_code.md
+++ b/dynamorio_docs/page_source_code.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_source_code.html
+---

--- a/dynamorio_docs/page_standalone.md
+++ b/dynamorio_docs/page_standalone.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_standalone.html
+---

--- a/dynamorio_docs/page_symquery.md
+++ b/dynamorio_docs/page_symquery.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_symquery.html
+---

--- a/dynamorio_docs/page_test_suite.md
+++ b/dynamorio_docs/page_test_suite.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_test_suite.html
+---

--- a/dynamorio_docs/page_tool.md
+++ b/dynamorio_docs/page_tool.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_tool.html
+---

--- a/dynamorio_docs/page_triager.md
+++ b/dynamorio_docs/page_triager.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_triager.html
+---

--- a/dynamorio_docs/page_tutorial_cgo16.md
+++ b/dynamorio_docs/page_tutorial_cgo16.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_tutorial_cgo16.html
+---

--- a/dynamorio_docs/page_tutorial_cgo17.md
+++ b/dynamorio_docs/page_tutorial_cgo17.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_tutorial_cgo17.html
+---

--- a/dynamorio_docs/page_tutorial_secdev16.md
+++ b/dynamorio_docs/page_tutorial_secdev16.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_tutorial_secdev16.html
+---

--- a/dynamorio_docs/page_tutorials.md
+++ b/dynamorio_docs/page_tutorials.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_tutorials.html
+---

--- a/dynamorio_docs/page_user_docs.md
+++ b/dynamorio_docs/page_user_docs.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_user_docs.html
+---

--- a/dynamorio_docs/page_weekly_builds.md
+++ b/dynamorio_docs/page_weekly_builds.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_weekly_builds.html
+---

--- a/dynamorio_docs/page_workflow.md
+++ b/dynamorio_docs/page_workflow.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /page_workflow.html
+---

--- a/dynamorio_docs/pages.md
+++ b/dynamorio_docs/pages.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /pages.html
+---

--- a/dynamorio_docs/raw2trace_8h.md
+++ b/dynamorio_docs/raw2trace_8h.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /raw2trace_8h.html
+---

--- a/dynamorio_docs/release_notes.md
+++ b/dynamorio_docs/release_notes.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /release_notes.html
+---

--- a/dynamorio_docs/reuse__distance__create_8h.md
+++ b/dynamorio_docs/reuse__distance__create_8h.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /reuse__distance__create_8h.html
+---

--- a/dynamorio_docs/reuse__time__create_8h.md
+++ b/dynamorio_docs/reuse__time__create_8h.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /reuse__time__create_8h.html
+---

--- a/dynamorio_docs/sec_drcachesim.md
+++ b/dynamorio_docs/sec_drcachesim.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /sec_drcachesim.html
+---

--- a/dynamorio_docs/sec_drcachesim_analyzer.md
+++ b/dynamorio_docs/sec_drcachesim_analyzer.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /sec_drcachesim_analyzer.html
+---

--- a/dynamorio_docs/sec_drcachesim_cmp.md
+++ b/dynamorio_docs/sec_drcachesim_cmp.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /sec_drcachesim_cmp.html
+---

--- a/dynamorio_docs/sec_drcachesim_config_file.md
+++ b/dynamorio_docs/sec_drcachesim_config_file.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /sec_drcachesim_config_file.html
+---

--- a/dynamorio_docs/sec_drcachesim_core.md
+++ b/dynamorio_docs/sec_drcachesim_core.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /sec_drcachesim_core.html
+---

--- a/dynamorio_docs/sec_drcachesim_extend.md
+++ b/dynamorio_docs/sec_drcachesim_extend.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /sec_drcachesim_extend.html
+---

--- a/dynamorio_docs/sec_drcachesim_funcs.md
+++ b/dynamorio_docs/sec_drcachesim_funcs.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /sec_drcachesim_funcs.html
+---

--- a/dynamorio_docs/sec_drcachesim_limit.md
+++ b/dynamorio_docs/sec_drcachesim_limit.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /sec_drcachesim_limit.html
+---

--- a/dynamorio_docs/sec_drcachesim_newtool.md
+++ b/dynamorio_docs/sec_drcachesim_newtool.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /sec_drcachesim_newtool.html
+---

--- a/dynamorio_docs/sec_drcachesim_offline.md
+++ b/dynamorio_docs/sec_drcachesim_offline.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /sec_drcachesim_offline.html
+---

--- a/dynamorio_docs/sec_drcachesim_ops.md
+++ b/dynamorio_docs/sec_drcachesim_ops.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /sec_drcachesim_ops.html
+---

--- a/dynamorio_docs/sec_drcachesim_partial.md
+++ b/dynamorio_docs/sec_drcachesim_partial.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /sec_drcachesim_partial.html
+---

--- a/dynamorio_docs/sec_drcachesim_phys.md
+++ b/dynamorio_docs/sec_drcachesim_phys.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /sec_drcachesim_phys.html
+---

--- a/dynamorio_docs/sec_drcachesim_run.md
+++ b/dynamorio_docs/sec_drcachesim_run.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /sec_drcachesim_run.html
+---

--- a/dynamorio_docs/sec_drcachesim_sim.md
+++ b/dynamorio_docs/sec_drcachesim_sim.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /sec_drcachesim_sim.html
+---

--- a/dynamorio_docs/sec_drcachesim_tools.md
+++ b/dynamorio_docs/sec_drcachesim_tools.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /sec_drcachesim_tools.html
+---

--- a/dynamorio_docs/sec_drcachesim_tracer.md
+++ b/dynamorio_docs/sec_drcachesim_tracer.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /sec_drcachesim_tracer.html
+---

--- a/dynamorio_docs/tlb__simulator__create_8h.md
+++ b/dynamorio_docs/tlb__simulator__create_8h.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /tlb__simulator__create_8h.html
+---

--- a/dynamorio_docs/trace__entry_8h.md
+++ b/dynamorio_docs/trace__entry_8h.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /trace__entry_8h.html
+---

--- a/dynamorio_docs/transparency.md
+++ b/dynamorio_docs/transparency.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /transparency.html
+---

--- a/dynamorio_docs/using.md
+++ b/dynamorio_docs/using.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /using.html
+---

--- a/dynamorio_docs/view__create_8h.md
+++ b/dynamorio_docs/view__create_8h.md
@@ -1,0 +1,5 @@
+---
+title: Redirect
+redirect_to:
+ - /view__create_8h.html
+---


### PR DESCRIPTION
Adds redirects for all dynamorio_docs/ pages except the API reference
pages.  With no web server config access, we're limited to single-page
redirects using jekyll.