### PR TITLE
Fall back to page on anchor with no menu entry

### DIFF
--- a/navtree.js
+++ b/navtree.js
@@ -473,6 +473,12 @@ function navTo(o,root,hash,relpath)
       indices.pop();
       ++indices[indices.length-1];
       if (arrays.length == 0) {
+        if (hash != '') {
+          // At least get the right page for anchors that don't have their
+          // own menu entries.
+          navTo(o, root, '', relpath);
+          return;
+        }
         indices = [0]; // fallback: show home
         break;
       }


### PR DESCRIPTION
When an anchor has no menu entry, the menu locator was falling back to
the home page.  Here we re-try without the anchor to at least point at
the containing page's menu entry.