### PR TITLE
Dead link

### DIFF
--- a/docs/page_home.html
+++ b/docs/page_home.html
@@ -57,7 +57,6 @@ Existing DynamoRIO-based tools</h1>
 <li>The instruction tracing tool <a href="https://github.com/DynamoRIO/dynamorio/blob/master/api/samples/instrace_x86.c">instrace</a> (<a class="el" href="page_drcachesim.html">drmemtrace</a>'s offline traces are faster with more surrounding infrastructure, but this is a simpler starting point for customized instruction tracing)</li>
 <li>The basic block tracing tool <a href="https://github.com/DynamoRIO/dynamorio/blob/master/api/samples/bbbuf.c">bbbuf</a></li>
 <li>The instruction counting tool <a href="https://github.com/DynamoRIO/dynamorio/blob/master/api/samples/inscount.c">inscount</a></li>
-<li>The dynamic fuzz testing tool <a href="http://drmemory.org/docs/page_drfuzz.html">Dr. Fuzz</a></li>
 <li>The disassembly tool <a class="el" href="page_drdisas.html">drdisas</a></li>
 <li>And more, including opcode counts, branch instrumentation, etc.: see <a class="el" href="API_samples.html">Sample Tools</a>.</li>
 </ul>


### PR DESCRIPTION
I've spotted that there's a dead link on DynamoRIO [home page](https://dynamorio.org/):
> * The dynamic fuzz testing tool [Dr. Fuzz](http://drmemory.org/docs/page_drfuzz.html) 

The `https://drmemory.org/docs/page_drfuzz.html` link seems not to exist or moved.

There was no clear way to report this kind of issue, so I've opened this PR. 
I could only find the template for DynamoRIO bugs.

Screenshot:
<img src="https://user-images.githubusercontent.com/6065236/234849090-23196db3-5c9b-4ded-b63b-507d41c34713.png" width=600/>
