### PR TITLE
i#6731: Add webrick dependency.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,4 +28,4 @@ gem "wdm", "~> 0.1.0" if Gem.win_platform?
 
 # webrick must now be included explicitly.
 # See: https://github.com/jekyll/jekyll/issues/8523
-gem "webrick"
+gem "webrick", "~> 1.8.1"

--- a/Gemfile
+++ b/Gemfile
@@ -26,3 +26,6 @@ gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 # Performance-booster for watching directories on Windows
 gem "wdm", "~> 0.1.0" if Gem.win_platform?
 
+# webrick must now be included explicitly.
+# See: https://github.com/jekyll/jekyll/issues/8523
+gem "webrick"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -253,6 +253,7 @@ GEM
       unf_ext
     unf_ext (0.0.8.2)
     unicode-display_width (1.8.0)
+    webrick (1.8.1)
     zeitwerk (2.6.6)
 
 PLATFORMS
@@ -267,6 +268,7 @@ DEPENDENCIES
   minima (~> 2.0)
   rexml (>= 3.2.5)
   tzinfo-data
+  webrick
 
 BUNDLED WITH
    2.3.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -268,7 +268,7 @@ DEPENDENCIES
   minima (~> 2.0)
   rexml (>= 3.2.5)
   tzinfo-data
-  webrick
+  webrick (~> 1.8.1)
 
 BUNDLED WITH
    2.3.4


### PR DESCRIPTION
Adds webrick gem dependency to dynamorio.github.io Gemfile. This enables jekyll to run as expected after a bundle install.

Fixes: DynamoRIO/dynamorio#6731